### PR TITLE
Only cleanup source files if translations in all languages are approved

### DIFF
--- a/lib/crowdin/client.rb
+++ b/lib/crowdin/client.rb
@@ -21,12 +21,17 @@ module CrowdIn
 
       RestClient.proxy = ENV['http_proxy'] if ENV['http_proxy']
       @connection = RestClient::Resource.new(base_url, options)
+
+      @files_cache = {}
     end
 
     # Get metadata for all files in a project
-    def files
-      path = "api/v2/projects/#{@project_id}/files"
-      with_pagination { |params| get_request(path, params) }
+    def files(hard_fetch = false)
+      if @files_cache.empty? || hard_fetch
+        path = "api/v2/projects/#{@project_id}/files"
+        @files_cache = with_pagination { |params| get_request(path, params) }
+      end
+      @files_cache
     end
 
     # Get the translation progress for a given file.

--- a/spec/crowdin/client_spec.rb
+++ b/spec/crowdin/client_spec.rb
@@ -37,6 +37,32 @@ RSpec.describe CrowdIn::Client do
         expect(subject.files).to eq response
       end
     end
+
+    context "with caching" do
+      let(:connection) { instance_double(RestClient::Resource) }
+
+      before do
+        subject.instance_variable_set(:@connection, connection)
+      end
+
+      it "uses cached results on subsequent calls" do
+        expect(connection).to receive(:options).exactly(:once).and_return({ params: {} })
+        expect(connection).to receive(:[]).exactly(:once).and_return(connection)
+        expect(connection).to receive(:get).exactly(:once).and_return(response)
+        # call #files twice and expect get request only once
+        expect(subject.files).to eq response
+        expect(subject.files).to eq response
+      end
+
+      it "fetches from CrowdIn if hard_fetch is requested" do
+        expect(connection).to receive(:options).exactly(:twice).and_return({ params: {} })
+        expect(connection).to receive(:[]).exactly(:twice).and_return(connection)
+        expect(connection).to receive(:get).exactly(:twice).and_return(response)
+        # call #files twice and expect get request twice with hard_fetch option
+        expect(subject.files(hard_fetch = true)).to eq response
+        expect(subject.files(hard_fetch = true)).to eq response
+      end
+    end
   end
 
   context "#file_status" do


### PR DESCRIPTION
Previously, we were cleaning up source files if translations were approved for that source file in any one language. This would mean that the source file would be deleted before it was sync'd down for the other languages (and possible deleted before they were even approved in CrowdIn for other languages). This was a mistake.

This PR fixes that by only cleaning up those source files in CrowdIn that have approved translations for ALL required languages by the app. Further it only performs that cleanup AFTER all translations for all required languages are sync'd successfully.

In order to make this a little more efficient, this PR also Implements basic caching in the CrowdIn Client code so that repeated API calls aren't made to CrowdIn to find file status.