### PR TITLE
Improvements to workers and clients

### DIFF
--- a/lib/crowdin/client.rb
+++ b/lib/crowdin/client.rb
@@ -23,6 +23,7 @@ module CrowdIn
       @connection = RestClient::Resource.new(base_url, options)
 
       @files_cache = {}
+      @files_status_cache = {}
     end
 
     # Get metadata for all files in a project
@@ -37,12 +38,16 @@ module CrowdIn
     # Get the translation progress for a given file.
     # If no language provided, then statuses for each languages: Array[translation_progress].
     # If specified language isn't found, returns nil.
-    def file_status(file_id, language = nil)
-      path = "api/v2/projects/#{@project_id}/files/#{file_id}/languages/progress"
+    def file_status(file_id, language = nil, hard_fetch = false)
+      if !@files_status_cache.key?(file_id) || hard_fetch
+        path = "api/v2/projects/#{@project_id}/files/#{file_id}/languages/progress"
+        @files_status_cache[file_id] = get_request(path)
+      end
+
       if language.nil?
-        get_request(path)
+        @files_status_cache[file_id]
       else
-        get_request(path).find { |s| s['languageId'] == language }
+        @files_status_cache[file_id].find { |s| s['languageId'] == language }
       end
     end
 

--- a/lib/crowdin/client.rb
+++ b/lib/crowdin/client.rb
@@ -51,8 +51,8 @@ module CrowdIn
     def language_status(language)
       files.map do |f|
         file_id = f['id']
-        file_status(file_id, language).merge('file_id' => file_id)
-      end
+        file_status(file_id, language)&.merge('file_id' => file_id)
+      end.compact
     end
 
     # Given a CrowdIn file_id, and a language, export the contents of the translated files.

--- a/lib/i18n_sonder/configuration.rb
+++ b/lib/i18n_sonder/configuration.rb
@@ -2,7 +2,7 @@ module I18nSonder
   class Configuration
     attr_accessor :crowdin_api_key, :crowdin_project_id, :logger
 
-    def initiailize
+    def initialize
       self.crowdin_api_key = nil
       self.crowdin_project_id = nil
       self.logger = nil

--- a/lib/i18n_sonder/workers/upload_source_strings_worker.rb
+++ b/lib/i18n_sonder/workers/upload_source_strings_worker.rb
@@ -6,6 +6,8 @@ module I18nSonder
     class UploadSourceStringsWorker
       include Sidekiq::Worker
 
+      sidekiq_options retry: 2
+
       def initialize
         @localization_provider = I18nSonder.localization_provider
         @logger = I18nSonder.logger
@@ -27,19 +29,19 @@ module I18nSonder
           updated_at = object.updated_at.to_i
           attributes_to_translate = object.attributes.slice(*translated_attribute_params.keys)
 
-          @logger.info("Uploading attributes to translate for #{object_type} #{object_id}")
+          @logger.info("[I18nSonder::UploadSourceStringsWorker] Uploading attributes to translate for #{object_type} #{object_id}")
           result = @localization_provider.upload_attributes_to_translate(
               object_type, object_id.to_s, updated_at, attributes_to_translate, translated_attribute_params
           )
           handle_failure(result.failure)
         else
-          @logger.error("Can't find #{object_type} #{object_id} to send for translation")
+          @logger.error("[I18nSonder::UploadSourceStringsWorker] Can't find #{object_type} #{object_id} to send for translation")
         end
       end
 
       def handle_failure(exception)
         if exception.is_a? Exception
-          @logger.error(exception)
+          @logger.error("[I18nSonder::UploadSourceStringsWorker] #{exception}")
         end
       end
     end

--- a/spec/crowdin/client_spec.rb
+++ b/spec/crowdin/client_spec.rb
@@ -109,6 +109,10 @@ RSpec.describe CrowdIn::Client do
       expected_response = [ { "file_id" => file1_id, "languageId" => "fr" }, { "file_id" => file2_id, "languageId" => "fr" } ]
       expect(subject.language_status(language)).to eq expected_response
     end
+
+    it "returns empty result for language that doesn't exist" do
+      expect(subject.language_status("bad_lang")).to eq []
+    end
   end
 
   context "methods that export content" do

--- a/spec/crowdin/client_spec.rb
+++ b/spec/crowdin/client_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe CrowdIn::Client do
         expect(connection).to receive(:[]).exactly(:twice).and_return(connection)
         expect(connection).to receive(:get).exactly(:twice).and_return(response)
         # call #files twice and expect get request twice with hard_fetch option
-        expect(subject.files(hard_fetch = true)).to eq response
+        expect(subject.files).to eq response
         expect(subject.files(hard_fetch = true)).to eq response
       end
     end
@@ -68,6 +68,7 @@ RSpec.describe CrowdIn::Client do
   context "#file_status" do
     let(:file_id) { "123" }
     let(:response_string) { '{ "data": [ { "data": { "languageId": "fr" } }, { "data": { "languageId": "es" } } ] }' }
+    let(:response) { [ { "languageId" => "fr" }, { "languageId" => "es" } ] }
 
     before do
       stub_request(:get, "#{base_path}/files/#{file_id}/languages/progress")
@@ -75,7 +76,7 @@ RSpec.describe CrowdIn::Client do
     end
 
     it "returns all language status when no language param specified" do
-      expect(subject.file_status(file_id)).to eq [ { "languageId" => "fr" }, { "languageId" => "es" } ]
+      expect(subject.file_status(file_id)).to eq response
     end
 
     it "returns expected response if expected language exists" do
@@ -84,6 +85,32 @@ RSpec.describe CrowdIn::Client do
 
     it "returns expected response if expected language doesn't exists" do
       expect(subject.file_status(file_id, "blah")).to eq nil
+    end
+
+    context "with caching" do
+      let(:connection) { instance_double(RestClient::Resource) }
+
+      before do
+        subject.instance_variable_set(:@connection, connection)
+      end
+
+      it "uses cached results on subsequent calls" do
+        expect(connection).to receive(:options).exactly(:once).and_return({ params: {} })
+        expect(connection).to receive(:[]).exactly(:once).and_return(connection)
+        expect(connection).to receive(:get).exactly(:once).and_return(response)
+        # call #files_status twice with different languages and expect get request only once
+        expect(subject.file_status(file_id, "fr")).to eq( { "languageId" => "fr" } )
+        expect(subject.file_status(file_id, "es")).to eq( { "languageId" => "es" } )
+      end
+
+      it "fetches from CrowdIn if hard_fetch is requested" do
+        expect(connection).to receive(:options).exactly(:twice).and_return({ params: {} })
+        expect(connection).to receive(:[]).exactly(:twice).and_return(connection)
+        expect(connection).to receive(:get).exactly(:twice).and_return(response)
+        # call #files_status twice and expect get request twice with hard_fetch option
+        expect(subject.file_status(file_id, "fr")).to eq( { "languageId" => "fr" } )
+        expect(subject.file_status(file_id, "fr", hard_fetch = true)).to eq( { "languageId" => "fr" } )
+      end
     end
   end
 

--- a/spec/i18n_sonder/workers/sync_approved_translations_worker_spec.rb
+++ b/spec/i18n_sonder/workers/sync_approved_translations_worker_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe I18nSonder::Workers::SyncApprovedTranslationsWorker do
 
         expect(adapter).to receive(:cleanup_translations).with({}, [:fr]).and_return(cleanup_response)
         allow(logger).to receive(:info)
-        expect(logger).to receive(:error).with(error).exactly(1).times
+        expect(logger).to receive(:error).with("[I18nSonder::SyncApprovedTranslationsWorker] #{error}").exactly(1).times
         subject.perform
       end
     end
@@ -107,7 +107,7 @@ RSpec.describe I18nSonder::Workers::SyncApprovedTranslationsWorker do
         expect(another_model).to receive(:update!).with('4', translations['AnotherModel']['4'])
         expect(adapter).to receive(:cleanup_translations).and_return(CrowdIn::Adapter::ReturnObject.new(nil, error))
         expect(logger).to receive(:info).exactly(5).times
-        expect(logger).to receive(:error).with(error).exactly(1).times
+        expect(logger).to receive(:error).with("[I18nSonder::SyncApprovedTranslationsWorker] #{error}").exactly(1).times
         subject.perform
       end
     end


### PR DESCRIPTION
1) limit retries to 2
2) CrowdIn client should be able to handle languages that don't exist
3) Cache file_status results from CrowdIn so we don't refetch for every language
4) Fix bug regarding attempting to fetch language that doesn't exist in CrowdIn