### PR TITLE
Create new CrowdIn Adapter for every worker perform call

### DIFF
--- a/lib/i18n_sonder.rb
+++ b/lib/i18n_sonder.rb
@@ -22,8 +22,9 @@ module I18nSonder
       @logger ||= Logger.new
     end
 
+    # Returns a new CrowdIn Adapter with a new CrowdIn Client.
     def localization_provider
-      @localization_provider ||= CrowdIn::Adapter.new(
+      CrowdIn::Adapter.new(
           CrowdIn::Client.new(
               api_key: I18nSonder.configuration.crowdin_api_key,
               project_id: I18nSonder.configuration.crowdin_project_id

--- a/lib/i18n_sonder/workers/sync_approved_translations_worker.rb
+++ b/lib/i18n_sonder/workers/sync_approved_translations_worker.rb
@@ -8,11 +8,12 @@ module I18nSonder
       sidekiq_options retry: 2
 
       def initialize
-        @localization_provider = I18nSonder.localization_provider
         @logger = I18nSonder.logger
       end
 
       def perform
+        localization_provider = I18nSonder.localization_provider
+
         successful_syncs = {}
         # Iterate through each language we need to sync
         languages_to_translate = I18n.available_locales.reject { |l| l == I18n.default_locale }
@@ -27,7 +28,7 @@ module I18nSonder
           #     }
           #   }
           # }
-          translation_result = @localization_provider.translations(language.to_s)
+          translation_result = localization_provider.translations(language.to_s)
           translations_by_model_and_id = translation_result.success
           handle_failure(translation_result.failure)
 
@@ -42,7 +43,7 @@ module I18nSonder
         end
 
         @logger.info("[I18nSonder::SyncApprovedTranslationsWorker] Cleaning up translations")
-        cleanup_result = @localization_provider.cleanup_translations(successful_syncs, languages_to_translate)
+        cleanup_result = localization_provider.cleanup_translations(successful_syncs, languages_to_translate)
         handle_failure(cleanup_result.failure)
       end
 

--- a/lib/i18n_sonder/workers/upload_source_strings_worker.rb
+++ b/lib/i18n_sonder/workers/upload_source_strings_worker.rb
@@ -9,7 +9,6 @@ module I18nSonder
       sidekiq_options retry: 2
 
       def initialize
-        @localization_provider = I18nSonder.localization_provider
         @logger = I18nSonder.logger
       end
 
@@ -22,6 +21,8 @@ module I18nSonder
       # +translated_attribute_params+ hash. The value in this hash is any relevant params on how
       # to upload these source strings for translations. The value can be empty for default values.
       def perform(object_type, object_id, translated_attribute_params)
+        localization_provider = I18nSonder.localization_provider
+
         # Find the object and all its localized attributes
         klass = object_type.constantize
         object = klass.find(object_id)
@@ -30,7 +31,7 @@ module I18nSonder
           attributes_to_translate = object.attributes.slice(*translated_attribute_params.keys)
 
           @logger.info("[I18nSonder::UploadSourceStringsWorker] Uploading attributes to translate for #{object_type} #{object_id}")
-          result = @localization_provider.upload_attributes_to_translate(
+          result = localization_provider.upload_attributes_to_translate(
               object_type, object_id.to_s, updated_at, attributes_to_translate, translated_attribute_params
           )
           handle_failure(result.failure)

--- a/spec/i18n_sonder/workers/sync_approved_translations_worker_spec.rb
+++ b/spec/i18n_sonder/workers/sync_approved_translations_worker_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe I18nSonder::Workers::SyncApprovedTranslationsWorker do
 
   subject do
     described_class.new.tap do |s|
-      s.instance_variable_set(:@localization_provider, adapter)
       s.instance_variable_set(:@logger, logger)
     end
   end
@@ -36,6 +35,7 @@ RSpec.describe I18nSonder::Workers::SyncApprovedTranslationsWorker do
     before do
       I18n.available_locales = [:en, :fr]
       I18n.default_locale = :en
+      expect(I18nSonder).to receive(:localization_provider).and_return(adapter)
     end
 
     it "fetches translations, writes them to the DB, and then cleans up successful syncs" do

--- a/spec/i18n_sonder/workers/upload_source_strings_worker_spec.rb
+++ b/spec/i18n_sonder/workers/upload_source_strings_worker_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe I18nSonder::Workers::UploadSourceStringsWorker do
 
   subject do
     described_class.new.tap do |s|
-      s.instance_variable_set(:@localization_provider, adapter)
       s.instance_variable_set(:@logger, logger)
     end
   end
@@ -30,6 +29,10 @@ RSpec.describe I18nSonder::Workers::UploadSourceStringsWorker do
 
   context "#perform" do
     let(:upload_response) { CrowdIn::Adapter::ReturnObject.new(nil, nil) }
+
+    before do
+      expect(I18nSonder).to receive(:localization_provider).and_return(adapter)
+    end
 
     it "fetches translations, writes them to the DB, and then cleans them up" do
       expect(model).to receive(:find).with(id).and_return(model_instance)


### PR DESCRIPTION
When the Clockwork gem executes a worker's perform() function, it does not always create a new worker. As a result, we end up using the same localization_provider every run. This means that all the caching is preserved across multiple runs, which is not the desired behavior. We want a brand new client object every run. This PR makes that change.