### PR TITLE
Bugfixes for finding files by names and objects without updated_at columns

### DIFF
--- a/lib/crowdin/client.rb
+++ b/lib/crowdin/client.rb
@@ -81,10 +81,13 @@ module CrowdIn
       delete_request(path)
     end
 
-    # Find the first file in CrowdIn whose name starts with given name.
+    # Find the first file in CrowdIn whose basename is equal to the given name.
+    # The +name+ argument must be the basename of the file, e.g. "File_123.json"'s
+    # basename is "File_123".
+    #
     # Return the files's id, if found, else return false.
     def find_file_by_name(name)
-      file = files.find { |f| f['name'].start_with? name }
+      file = files.find { |f| name == File.basename(f['name'], ".*") }
       file.present? ? file['id'] : false
     end
 

--- a/lib/i18n_sonder/workers/upload_source_strings_worker.rb
+++ b/lib/i18n_sonder/workers/upload_source_strings_worker.rb
@@ -27,7 +27,7 @@ module I18nSonder
         klass = object_type.constantize
         object = klass.find(object_id)
         if object.present?
-          updated_at = object.updated_at.to_i
+          updated_at = object.has_attribute?(:updated_at) ? object.updated_at.to_i : nil
           attributes_to_translate = object.attributes.slice(*translated_attribute_params.keys)
 
           @logger.info("[I18nSonder::UploadSourceStringsWorker] Uploading attributes to translate for #{object_type} #{object_id}")

--- a/spec/crowdin/adapter_spec.rb
+++ b/spec/crowdin/adapter_spec.rb
@@ -9,11 +9,13 @@ RSpec.describe CrowdIn::Adapter do
   let(:file1_id) { '1' }
   let(:file2_id) { '2' }
   let(:file3_id) { '3' }
+  let(:file4_id) { '4' }
   let(:status) {
     [
         { "file_id" => file1_id, "approvalProgress" => 100 },
         { "file_id" => file2_id, "approvalProgress" => 75 },
         { "file_id" => file3_id, "approvalProgress" => 100 },
+        { "file_id" => file4_id, "approvalProgress" => 100 },
     ]
   }
   let(:raw_translations_1) {
@@ -28,10 +30,14 @@ RSpec.describe CrowdIn::Adapter do
         "555" => { "field1" => "val 1", "field2" => "val 2" }
     } } }
   }
+  let(:raw_translations_3) {
+    { "ModelWithoutUpdated" => { "1" => { "field1" => "val 1", "field2" => "val 2" } } }
+  }
   let(:expected_output) {
     {
         "Model" => { "1" => { "field1" => "val 3", "field2" => "val 2" } },
-        "AnotherModel" => { "1" => { "field1" => "val 3", "field2" => "val 2" } }
+        "AnotherModel" => { "1" => { "field1" => "val 3", "field2" => "val 2" } },
+        "ModelWithoutUpdated" => { "1" => { "field1" => "val 1", "field2" => "val 2" } }
     }
   }
 
@@ -40,6 +46,7 @@ RSpec.describe CrowdIn::Adapter do
       expect(client).to receive(:language_status).with(language).and_return(status)
       expect(client).to receive(:export_file).with(file1_id, language).and_return(raw_translations_1)
       expect(client).to receive(:export_file).with(file3_id, language).and_return(raw_translations_2)
+      expect(client).to receive(:export_file).with(file4_id, language).and_return(raw_translations_3)
 
       r = subject.translations(language)
       expect(r.success).to eq expected_output
@@ -50,6 +57,7 @@ RSpec.describe CrowdIn::Adapter do
       expect(client).to receive(:language_status).with(language).and_return(status)
       expect(client).to receive(:export_file).with(file1_id, language).and_raise(error)
       expect(client).to receive(:export_file).with(file3_id, language).and_return(raw_translations_2)
+      expect(client).to receive(:export_file).with(file4_id, language).and_return(raw_translations_3)
 
       r = subject.translations(language)
       expect(r.success).to eq(expected_output.except("Model"))
@@ -75,6 +83,14 @@ RSpec.describe CrowdIn::Adapter do
 
       r = subject.translations_for_file(file1_id, language)
       expect(r.success).to eq expected_output
+      expect(r.failure).to be_nil
+    end
+
+    it "returns translations for given file when object doesn't have updated_at" do
+      expect(client).to receive(:export_file).with(file1_id, language).and_return(raw_translations_3)
+
+      r = subject.translations_for_file(file1_id, language)
+      expect(r.success).to eq({ "ModelWithoutUpdated" => { "1" => { "field1" => "val 1", "field2" => "val 2" } } })
       expect(r.failure).to be_nil
     end
 
@@ -234,6 +250,22 @@ RSpec.describe CrowdIn::Adapter do
         r = subject.upload_attributes_to_translate(object_type, object_id, updated_at, attributes, params)
         expect(r.success).to be_nil
         expect(r.failure).to eq error
+      end
+    end
+
+    context "for an object without the updated_at column" do
+      let(:content) { { object_type => { object_id => {
+          "field1" => "val 1. val 2.",
+          "field2" => [ "val 3.", "val 4." ]
+      } } }.to_json }
+
+      it "adds a new file with content split by sentences according to params" do
+        expect(client).to receive(:find_file_by_name).with(file_base_name).and_return(false)
+        expect(client).to receive(:add_file).with(file_name, content).and_return(nil)
+
+        r = subject.upload_attributes_to_translate(object_type, object_id, nil, attributes, params)
+        expect(r.success).to be_nil
+        expect(r.failure).to be_nil
       end
     end
 

--- a/spec/crowdin/adapter_spec.rb
+++ b/spec/crowdin/adapter_spec.rb
@@ -206,6 +206,17 @@ RSpec.describe CrowdIn::Adapter do
         expect(r.failure).to be_nil
       end
 
+      it "does not update if object not found in source file" do
+        existing_content = { object_type => { "other_object_id" => { "1000" => {} } } }
+        expect(client).to receive(:download_source_file).with(file1_id).and_return(existing_content)
+        expect(client).not_to receive(:update_file)
+
+        r = subject.upload_attributes_to_translate(object_type, object_id, updated_at, attributes, params)
+        expect(r.success).to be_nil
+        expected_error = CrowdIn::FileMethods::FilesError.new({ file1_id => "Could not find #{object_type} #{object_id}" })
+        expect(r.failure).to eq expected_error
+      end
+
       it "returns failures when downloading file errors" do
         expect(client).to receive(:download_source_file).with(file1_id).and_raise(error)
         expect(client).not_to receive(:update_file)

--- a/spec/crowdin/client_spec.rb
+++ b/spec/crowdin/client_spec.rb
@@ -258,6 +258,11 @@ RSpec.describe CrowdIn::Client do
     it "returns false when name is not found" do
       expect(subject.find_file_by_name("not_found")).to eq false
     end
+
+    it "returns false when given name and existing file names are substrings of one another" do
+      expect(subject.find_file_by_name("file_12")).to eq false
+      expect(subject.find_file_by_name("file_1234")).to eq false
+    end
   end
 
   context "mutating files" do


### PR DESCRIPTION
This PR addresses 2 separate issues:
1) When looking for a file whose name is a substring of an existing file name, we currently find that file as a match, even though that is not correct. For example, "File_12.json", and "File_123.json" do not refer to the same objects. This PR fixes this bug.
2) If a Model did not have an updated_at column, then the workers would not be able to upload or sync translations. This PR laxes that requirement and allows support for models that don't have an updated_at column.