### PR TITLE
Only upload new translations if attribute value changes

### DIFF
--- a/lib/mobility/plugins/upload_for_translation.rb
+++ b/lib/mobility/plugins/upload_for_translation.rb
@@ -14,8 +14,11 @@ module Mobility
       UPLOAD_TRANSLATION_DELAY = (ENV["UPLOAD_FOR_TRANSLATION_DELAY_MIN"] || 5).minutes
 
       def write(locale, value, options = {})
-        # Only upload for translation if we are writing content in the default locale
-        if locale == I18n.default_locale
+        old_value = model.read_attribute(attribute)
+
+        # Only upload for translation if we are writing content in the default locale,
+        # and if the new value being written is different to the already existing value.
+        if locale == I18n.default_locale && value != old_value
           # Get translated attributes, and each attribute's params for uploading translations
           translated_attribute_names = model_class.translated_attribute_names
           translated_attribute_params = {}


### PR DESCRIPTION
Previously, we were uploading content for translation regardless of whether the content was different or not. This leads to quite a large amount of API requests made to CrowdIn, which is wasteful. Here, we make the change such that only if the value is changing do we schedule a job to upload content for translation.