### PR TITLE
Find duplicate translations before uploading for translation

### DIFF
--- a/lib/crowdin/adapter.rb
+++ b/lib/crowdin/adapter.rb
@@ -35,6 +35,7 @@ module CrowdIn
     def upload_attributes_to_translate(object_type, object_id, updated_at, attributes, attribute_params)
       # Find the CrowdIn File corresponding to object.
       to_return = ReturnObject.new(nil, nil)
+      return to_return if attributes.empty?
       begin
         file_name = file_name(object_type, object_id)
         file_base_name = File.basename(file_name, ".*")

--- a/lib/i18n_sonder/workers/upload_source_strings_worker.rb
+++ b/lib/i18n_sonder/workers/upload_source_strings_worker.rb
@@ -10,6 +10,7 @@ module I18nSonder
 
       def initialize
         @logger = I18nSonder.logger
+        @log_pre = "[I18nSonder::UploadSourceStringsWorker]"
       end
 
       # Find the object, given type and id, and extract all of the required attributes.
@@ -28,22 +29,90 @@ module I18nSonder
         object = klass.find(object_id)
         if object.present?
           updated_at = object.has_attribute?(:updated_at) ? object.updated_at.to_i : nil
-          attributes_to_translate = object.attributes.slice(*translated_attribute_params.keys)
+          attributes_to_translate = handle_duplicates(
+              object,
+              klass,
+              object.attributes.slice(*translated_attribute_params.keys)
+          )
 
-          @logger.info("[I18nSonder::UploadSourceStringsWorker] Uploading attributes to translate for #{object_type} #{object_id}")
+          @logger.info("#{@log_pre} Uploading attributes #{attributes_to_translate.keys} to translate for #{object_type} #{object_id}")
           result = localization_provider.upload_attributes_to_translate(
               object_type, object_id.to_s, updated_at, attributes_to_translate, translated_attribute_params
           )
           handle_failure(result.failure)
         else
-          @logger.error("[I18nSonder::UploadSourceStringsWorker] Can't find #{object_type} #{object_id} to send for translation")
+          @logger.error("#{@log_pre} Can't find #{object_type} #{object_id} to send for translation")
         end
       end
 
       def handle_failure(exception)
         if exception.is_a? Exception
-          @logger.error("[I18nSonder::UploadSourceStringsWorker] #{exception}")
+          @logger.error("#{@log_pre} #{exception}")
         end
+      end
+
+      private
+
+      # Look for duplicates of any of the +attributes_to_translate+, and update this model with valid duplicates.
+      # Filter down +attributes_to_translate+ to only the attribute-value pairs that don't have duplicate translations
+      # in all of the +I18nSonder.languages_to_translate+, since we do not need to upload those for translation.
+      def handle_duplicates(object, klass, attributes_to_translate)
+        locales_to_translate = I18nSonder.languages_to_translate.reject { |l| l == I18n.default_locale }.to_set
+
+        duplicates = duplicate_translations2(klass, attributes_to_translate)
+
+        duplicate_attrs_to_locales = attributes_to_translate.map { |a, _| [a, []] }.to_h
+
+        # require 'pry'
+        # binding.pry
+        duplicates.each do |locale, translations|
+          unless translations.empty?
+            Mobility.with_locale(locale) do
+              @logger.info("#{@log_pre} Updating #{klass} #{object.id} with duplicate #{locale} translations for #{translations.keys}")
+              object.update(translations)
+            end
+          end
+
+          translations.each do |attr, _|
+            duplicate_attrs_to_locales[attr].append(locale)
+          end
+        end
+
+        attributes_to_translate.select do |attr, _|
+          locales_to_translate != duplicate_attrs_to_locales[attr].map(&:to_sym).to_set
+        end
+      end
+
+      # Look through all other models for translations of the same attribute-value pairs that need translation.
+      # Return those duplicates as a hash:
+      # { fr: { attribute1: "..." }, es: { attribute1: "..." }, ... }
+      #
+      # Valid translations are those where:
+      # 1) the attribute-values are equal for the model we are updating and the model we are comparing
+      # 2) the translation isn't stale (its updated time is after the translatable object's updated time)
+      #
+      # If there are multiple translations, take the one with the latest updated_at timestamp.
+      def duplicate_translations2(klass, attributes_to_translate)
+        attributes_to_translate.inject({}) do |translations_by_locale, (attr, value)|
+          duplicates = klass.joins("as k INNER JOIN #{translation_table_name(attr)} as t "\
+                    "ON t.translatable_id = k.id "\
+                    "AND t.translatable_type = '#{klass}' "\
+                    "AND t.key = '#{attr}'")
+                           .select("DISTINCT ON (t.locale) t.locale, t.value")
+                           .where("k.#{attr} = ?", value)
+                           .where("date_trunc('second', t.updated_at) >= date_trunc('second', k.updated_at)")
+                           .order("t.locale, t.updated_at desc")
+
+          translations_by_locale.deep_merge(
+              duplicates.map { |d| [d.locale, { attr => d.value }] }.to_h
+          )
+        end
+      end
+
+      # Note: This method for getting the translation table name for a given attribute
+      # is specific to the Key-Value Mobility backend.
+      def translation_table_name(attribute)
+        klass.mobility_backend_class(attribute).class_name.arel_table.name
       end
     end
   end

--- a/lib/i18n_sonder/workers/upload_source_strings_worker.rb
+++ b/lib/i18n_sonder/workers/upload_source_strings_worker.rb
@@ -63,8 +63,6 @@ module I18nSonder
 
         duplicate_attrs_to_locales = attributes_to_translate.map { |a, _| [a, []] }.to_h
 
-        # require 'pry'
-        # binding.pry
         duplicates.each do |locale, translations|
           unless translations.empty?
             Mobility.with_locale(locale) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,8 @@ ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: ':memory:'
 
 I18n.enforce_available_locales = false
 
+RSpec::Mocks.configuration.allow_message_expectations_on_nil = true
+
 RSpec.configure do |config|
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true


### PR DESCRIPTION
This is an optimization performed asynchronously in the UploadSourceStringsWorker.
We will now look through the translations tables, and look for existing
translations for the strings we are planning to upload for translation.
We apply the duplicate translations, and if all locales have existing
translations for any attribute, we do not upload that attribute for
translation.

CAVEAT: This optimization assumes that the Key-Value Mobility backend is
being used. It is not implemented in a flexible enough way to be
backend-agnostic.