### PR TITLE
Allow conditionally uploading strings for translation for models

### DIFF
--- a/lib/mobility/plugins/upload_for_translation.rb
+++ b/lib/mobility/plugins/upload_for_translation.rb
@@ -14,11 +14,7 @@ module Mobility
       UPLOAD_TRANSLATION_DELAY = (ENV["UPLOAD_FOR_TRANSLATION_DELAY_MIN"] || 5).minutes
 
       def write(locale, value, options = {})
-        old_value = model.read_attribute(attribute)
-
-        # Only upload for translation if we are writing content in the default locale,
-        # and if the new value being written is different to the already existing value.
-        if locale == I18n.default_locale && value != old_value && model[:id].present?
+        if should_upload_for_translation?(model)
           # Get translated attributes, and each attribute's params for uploading translations
           translated_attribute_names = model_class.translated_attribute_names
           translated_attribute_params = {}
@@ -35,6 +31,27 @@ module Mobility
         end
 
         super
+      end
+
+      private
+
+      # Only upload for translation if:
+      # 1) we are writing content in the default locale
+      # 2) the new value being written is different to the already existing value.
+      # 3) there is an ID present for the model
+      # 4) if any predicate was passed in for this model's translatable field, then that evaluates to true
+      def should_upload_for_translation?(model)
+        is_default_locale = locale == I18n.default_locale
+
+        old_value = model.read_attribute(attribute)
+        is_different_new_value = value != old_value
+
+        model_id_present = model[:id].present?
+
+        pred = model.public_send("#{attribute}_backend").options.dig(:upload_for_translation, :predicate)
+        eval_pred = pred.nil? || pred.call(model)
+
+        is_default_locale && is_different_new_value && model_id_present && eval_pred
       end
     end
   end

--- a/lib/mobility/plugins/upload_for_translation.rb
+++ b/lib/mobility/plugins/upload_for_translation.rb
@@ -14,7 +14,7 @@ module Mobility
       UPLOAD_TRANSLATION_DELAY = (ENV["UPLOAD_FOR_TRANSLATION_DELAY_MIN"] || 5).minutes
 
       def write(locale, value, options = {})
-        if should_upload_for_translation?(model)
+        if should_upload_for_translation?(model, locale, value, attribute)
           # Get translated attributes, and each attribute's params for uploading translations
           translated_attribute_names = model_class.translated_attribute_names
           translated_attribute_params = {}
@@ -39,8 +39,8 @@ module Mobility
       # 1) we are writing content in the default locale
       # 2) the new value being written is different to the already existing value.
       # 3) there is an ID present for the model
-      # 4) if any predicate was passed in for this model's translatable field, then that evaluates to true
-      def should_upload_for_translation?(model)
+      # 4) if this model is allowed for translation
+      def should_upload_for_translation?(model, locale, value, attribute)
         is_default_locale = locale == I18n.default_locale
 
         old_value = model.read_attribute(attribute)
@@ -48,10 +48,11 @@ module Mobility
 
         model_id_present = model[:id].present?
 
-        pred = model.public_send("#{attribute}_backend").options.dig(:upload_for_translation, :predicate)
-        eval_pred = pred.nil? || pred.call(model)
+        # Check if model has the method defined and if it evaluates to true
+        model_allowed_for_translation = !model.class.method_defined?(:allowed_for_translation?) ||
+            model.allowed_for_translation?
 
-        is_default_locale && is_different_new_value && model_id_present && eval_pred
+        is_default_locale && is_different_new_value && model_id_present && model_allowed_for_translation
       end
     end
   end

--- a/spec/mobility/plugins/upload_for_translation_spec.rb
+++ b/spec/mobility/plugins/upload_for_translation_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Mobility::Plugins::UploadForTranslation do
       end
     end
 
-    context "that evaluates to false" do
+    context "that evaluates to true" do
       before do
         class Post < ActiveRecord::Base
           def allowed_for_translation?; true; end

--- a/spec/mobility/plugins/upload_for_translation_spec.rb
+++ b/spec/mobility/plugins/upload_for_translation_spec.rb
@@ -29,8 +29,9 @@ RSpec.describe Mobility::Plugins::UploadForTranslation do
   context "for instance without id" do
     let(:instance) { Post.new(title: "T1", content: "some content", published: true) }
 
-    it "does not call async worker" do
+    it "does not upload for translation" do
       expect(worker_class_mock).not_to receive(:perform_in)
+      instance.save!
     end
   end
 
@@ -40,9 +41,47 @@ RSpec.describe Mobility::Plugins::UploadForTranslation do
       I18n.default_locale = :en
     end
 
-    it "should be a no-op" do
+    it "does not upload for translation" do
       expect(worker_class_mock).not_to receive(:perform_in)
       instance.save!
+    end
+  end
+
+  context "for instance with allowed_for_translation? method" do
+    context "that evaluates to false" do
+      before do
+        class Post < ActiveRecord::Base
+          def allowed_for_translation?; false; end
+        end
+      end
+
+      let(:allowed) { false }
+      it "does not upload for translation" do
+        expect(worker_class_mock).not_to receive(:perform_in)
+        instance.save!
+      end
+    end
+
+    context "that evaluates to false" do
+      before do
+        class Post < ActiveRecord::Base
+          def allowed_for_translation?; true; end
+        end
+      end
+
+      let(:allowed) { false }
+      it "does not upload for translation" do
+        expect(worker_class_mock).to(
+            receive(:perform_in).with(5.minutes, 'Post', id, attribute_params).exactly(2).times
+        )
+        instance.save!
+      end
+    end
+
+    after do
+      class Post < ActiveRecord::Base
+        remove_method(:allowed_for_translation?)
+      end
     end
   end
 end


### PR DESCRIPTION
This change allows models that extend `mobility` to define a `allowed_for_translation?` method, which will be called before we upload the model for translation.