### PR TITLE
Allow to namespace source strings in CrowdIn into directories

### DIFF
--- a/lib/crowdin/adapter.rb
+++ b/lib/crowdin/adapter.rb
@@ -66,7 +66,7 @@ module CrowdIn
           if options.key?(:namespace)
             dir_name = options[:namespace].last
             directory = @client.find_directory_by_name(dir_name)
-            directory = @client.add_directory(dir_name) unless directory.present?
+            directory = @client.add_directory(dir_name) unless directory
             @client.add_file(file_name, file_content, directory)
           else
             @client.add_file(file_name, file_content)

--- a/lib/crowdin/adapter.rb
+++ b/lib/crowdin/adapter.rb
@@ -22,17 +22,20 @@ module CrowdIn
     # which we store in the CrowdIn translation file and used to resolve duplicates.
     # Can be nil when the object has no +updated_at+ column.
     # +attributes+ - key value pairs of attribute name to attribute values in english to translate
-    # +attribute_params+ - optional params per attribute_key.
-    # +attribute_params[:split_into_sentences]+ - indicates whether to split this attribute value into sentences
-    # on upload to CrowdIn. This allows for greater de-duplication, but can't be done with text that is heavily
-    # templated, as an example, since we can break sentences across template format tags.
+    # +options+
+    #   +attribute_params+ - optional params per attribute_key.
+    #     +attribute_params[:split_into_sentences]+ - indicates whether to split this attribute
+    #     value into sentences on upload to CrowdIn. This allows for greater de-duplication,
+    #     but can't be done with text that is heavily templated, as an example,
+    #     since we can break sentences across template format tags.
+    #   +namespace+ - optional array specifying the directory to upload source strings to.
     #
     # For objects that already have a translation file in CrowdIn, we simple replace its content if the current
     # +updated_at+ timestamp is later than what is present in CrowdIn.
     #
     # The returned +ReturnObject.failure+ is non-empty if there are errors.
     # The returned +ReturnObject.success+ is +nil+ regardless of success/failure.
-    def upload_attributes_to_translate(object_type, object_id, updated_at, attributes, attribute_params)
+    def upload_attributes_to_translate(object_type, object_id, updated_at, attributes, options)
       # Find the CrowdIn File corresponding to object.
       to_return = ReturnObject.new(nil, nil)
       return to_return if attributes.empty?
@@ -40,7 +43,9 @@ module CrowdIn
         file_name = file_name(object_type, object_id)
         file_base_name = File.basename(file_name, ".*")
         file_id = @client.find_file_by_name(file_base_name)
-        file_content = file_content_for_translations(object_type, object_id, updated_at, attributes, attribute_params)
+        file_content = file_content_for_translations(
+          object_type, object_id, updated_at, attributes, options[:translated_attribute_params]
+        )
 
         if file_id && updated_at.present?
           # If file exists, check updated timestamps, and update only if we don't have the latest timestamp's attributes
@@ -58,7 +63,14 @@ module CrowdIn
           end
         else
           # If file doesn't exist for object, create it with attributes to translate
-          @client.add_file(file_name, file_content)
+          if options.key?(:namespace)
+            dir_name = options[:namespace].last
+            directory = @client.find_directory_by_name(dir_name)
+            directory = @client.add_directory(dir_name) unless directory.present?
+            @client.add_file(file_name, file_content, directory)
+          else
+            @client.add_file(file_name, file_content)
+          end
         end
       rescue CrowdIn::Client::Errors::Error => e
         ReturnObject.new(nil, e)

--- a/lib/crowdin/client.rb
+++ b/lib/crowdin/client.rb
@@ -23,6 +23,7 @@ module CrowdIn
       @connection = RestClient::Resource.new(base_url, options)
 
       @files_cache = {}
+      @directories_cache = {}
       @files_status_cache = {}
     end
 
@@ -33,6 +34,15 @@ module CrowdIn
         @files_cache = with_pagination { |params| get_request(path, params) }
       end
       @files_cache
+    end
+
+    # Get metadata for all files in a project
+    def directories(hard_fetch = false)
+      if @directories_cache.empty? || hard_fetch
+        path = "api/v2/projects/#{@project_id}/directories"
+        @directories_cache = with_pagination { |params| get_request(path, params) }
+      end
+      @directories_cache
     end
 
     # Get the translation progress for a given file.
@@ -85,21 +95,33 @@ module CrowdIn
     # The +name+ argument must be the basename of the file, e.g. "File_123.json"'s
     # basename is "File_123".
     #
-    # Return the files's id, if found, else return false.
+    # Return the file's id, if found, else return false.
     def find_file_by_name(name)
       file = files.find { |f| name == File.basename(f['name'], ".*") }
       file.present? ? file['id'] : false
     end
 
+    # Find the first directory in CrowdIn whose name is equal to the given name.
+    # Note, if there are multiple sub-directories with the same names across the
+    # project, then this function will simply return the first found. As a result,
+    # there is an implicit assumption that all directories are uniquely named.
+    #
+    # Return the directory's id, if found, else return false.
+    def find_directory_by_name(name)
+      directory = directories.find { |f| name == f['name'] }
+      directory.present? ? directory['id'] : false
+    end
+
     # Add a new file given file name and content.
     # This first creates a storage object in CrowdIn, and then applies that
     # storage to a new file.
-    def add_file(name, content)
+    def add_file(name, content, directory_id = None)
       storage = add_storage(name, content)
 
       path = "api/v2/projects/#{@project_id}/files"
-      body = { storageId: storage['id'], name: storage['fileName'] }.to_json
-      post_request(path, body, content_type: :json)
+      body = { storageId: storage['id'], name: storage['fileName'] }
+      body[:directoryId] = directory_id if directory_id.present?
+      post_request(path, body.to_json, content_type: :json)
     end
 
     def add_storage(name, content)
@@ -107,6 +129,15 @@ module CrowdIn
       body = content
       headers = { :"Crowdin-API-FileName" => name, content_type: :json }
       post_request(path, body, headers)
+    end
+
+    # Add a new directory to root with the given name, and return the
+    # directory's id.
+    def add_directory(name)
+      path = "api/v2/projects/#{@project_id}/directories"
+      body = { name: name }
+      directory = post_request(path, body.to_json, content_type: :json)
+      directory.present? ? directory['id'] : false
     end
 
     # Given a CrowdIn, retrieve the contents of that file.

--- a/lib/crowdin/client.rb
+++ b/lib/crowdin/client.rb
@@ -115,7 +115,7 @@ module CrowdIn
     # Add a new file given file name and content.
     # This first creates a storage object in CrowdIn, and then applies that
     # storage to a new file.
-    def add_file(name, content, directory_id = None)
+    def add_file(name, content, directory_id = nil)
       storage = add_storage(name, content)
 
       path = "api/v2/projects/#{@project_id}/files"
@@ -133,9 +133,10 @@ module CrowdIn
 
     # Add a new directory to root with the given name, and return the
     # directory's id.
-    def add_directory(name)
+    def add_directory(name, parent_directory_id = nil)
       path = "api/v2/projects/#{@project_id}/directories"
       body = { name: name }
+      body[:directoryId] = parent_directory_id if parent_directory_id.present?
       directory = post_request(path, body.to_json, content_type: :json)
       directory.present? ? directory['id'] : false
     end

--- a/lib/i18n_sonder/workers/upload_source_strings_worker.rb
+++ b/lib/i18n_sonder/workers/upload_source_strings_worker.rb
@@ -35,7 +35,7 @@ module I18nSonder
           attributes_to_translate = handle_duplicates(
               object,
               klass,
-              object.attributes.slice(*options[:translated_attribute_params].keys)
+              object.attributes.slice(*options[:translated_attribute_params]&.keys)
           )
 
           @logger.info("#{@log_pre} Uploading attributes #{attributes_to_translate.keys} to translate for #{object_type} #{object_id}")

--- a/lib/mobility/plugins/upload_for_translation.rb
+++ b/lib/mobility/plugins/upload_for_translation.rb
@@ -26,7 +26,13 @@ module Mobility
           # Asynchronously upload attributes for translations
           # Include a delay so that multiple edits to the same object can be 'de-duped' in the async job.
           I18nSonder::Workers::UploadSourceStringsWorker.perform_in(
-              UPLOAD_TRANSLATION_DELAY, model.class.name, model[:id], translated_attribute_params
+              UPLOAD_TRANSLATION_DELAY,
+              model.class.name,
+              model[:id],
+              {
+                translated_attribute_params: translated_attribute_params,
+                namespace: namespace
+              }
           )
         end
 
@@ -34,6 +40,12 @@ module Mobility
       end
 
       private
+
+      def namespace
+        if model.class.method_defined?(:namespace_for_translation)
+          model.namespace_for_translation
+        end
+      end
 
       # Only upload for translation if:
       # 1) we are writing content in the default locale

--- a/spec/i18n_sonder/workers/upload_source_strings_worker_spec.rb
+++ b/spec/i18n_sonder/workers/upload_source_strings_worker_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe I18nSonder::Workers::UploadSourceStringsWorker do
   let(:type) { 'Model'}
   let(:updated) { 123 }
   let(:attribute_params) { { "field1" => {}, "field3" => { foo: true } } }
+  let(:options) { { translated_attribute_params: attribute_params } }
   let(:attributes_to_translate) { { "field1" => "val 1", "field3" => "val 3" } }
 
   let(:error) { CrowdIn::Client::Errors::Error.new(404, "not found") }
@@ -51,12 +52,12 @@ RSpec.describe I18nSonder::Workers::UploadSourceStringsWorker do
       expect(model_instance).to receive(:attributes).and_return(attributes)
       expect(adapter).to(
           receive(:upload_attributes_to_translate)
-              .with(type, id.to_s, updated, attributes_to_translate, attribute_params)
+              .with(type, id.to_s, updated, attributes_to_translate, options)
               .and_return(upload_response)
       )
       expect(logger).to receive(:info).exactly(1).times
       expect(logger).not_to receive(:error)
-      subject.perform(type, id, attribute_params)
+      subject.perform(type, id, options)
     end
 
     context "when model does not have an updated_at column" do
@@ -66,12 +67,12 @@ RSpec.describe I18nSonder::Workers::UploadSourceStringsWorker do
         expect(model_instance).to receive(:attributes).and_return(attributes)
         expect(adapter).to(
             receive(:upload_attributes_to_translate)
-                .with(type, id.to_s, nil, attributes_to_translate, attribute_params)
+                .with(type, id.to_s, nil, attributes_to_translate, options)
                 .and_return(upload_response)
         )
         expect(logger).to receive(:info).exactly(1).times
         expect(logger).not_to receive(:error)
-        subject.perform(type, id, attribute_params)
+        subject.perform(type, id, options)
       end
     end
 
@@ -85,7 +86,7 @@ RSpec.describe I18nSonder::Workers::UploadSourceStringsWorker do
 
         expect(logger).not_to receive(:info)
         expect(logger).to receive(:error).exactly(1).times
-        subject.perform(type, id, attribute_params)
+        subject.perform(type, id, options)
       end
     end
 
@@ -98,13 +99,13 @@ RSpec.describe I18nSonder::Workers::UploadSourceStringsWorker do
         expect(model_instance).to receive(:attributes).and_return(attributes)
         expect(adapter).to(
             receive(:upload_attributes_to_translate)
-                .with(type, id.to_s, updated, attributes_to_translate, attribute_params)
+                .with(type, id.to_s, updated, attributes_to_translate, options)
                 .and_return(upload_response)
         )
 
         expect(logger).to receive(:info).exactly(1).times
         expect(logger).to receive(:error).exactly(1).times
-        subject.perform(type, id, attribute_params)
+        subject.perform(type, id, options)
       end
     end
 
@@ -130,12 +131,12 @@ RSpec.describe I18nSonder::Workers::UploadSourceStringsWorker do
             expect(model_instance).to receive(:update).with(spanish_attrs).exactly(:once)
             expect(adapter).to(
                 receive(:upload_attributes_to_translate)
-                    .with(type, id.to_s, updated, {}, attribute_params)
+                    .with(type, id.to_s, updated, {}, options)
                     .and_return(upload_response)
             )
 
             expect(logger).to receive(:info).exactly(3).times
-            subject.perform(type, id, attribute_params)
+            subject.perform(type, id, options)
           end
         end
 
@@ -147,12 +148,12 @@ RSpec.describe I18nSonder::Workers::UploadSourceStringsWorker do
             expect(model_instance).to receive(:update).with(french_attrs).exactly(:once)
             expect(adapter).to(
                 receive(:upload_attributes_to_translate)
-                    .with(type, id.to_s, updated, attributes_to_translate, attribute_params)
+                    .with(type, id.to_s, updated, attributes_to_translate, options)
                     .and_return(upload_response)
             )
 
             expect(logger).to receive(:info).exactly(2).times
-            subject.perform(type, id, attribute_params)
+            subject.perform(type, id, options)
           end
         end
       end
@@ -168,12 +169,12 @@ RSpec.describe I18nSonder::Workers::UploadSourceStringsWorker do
             expect(model_instance).to receive(:update).with(spanish_attrs).exactly(:once)
             expect(adapter).to(
                 receive(:upload_attributes_to_translate)
-                    .with(type, id.to_s, updated, attributes_to_translate.except("field1"), attribute_params)
+                    .with(type, id.to_s, updated, attributes_to_translate.except("field1"), options)
                     .and_return(upload_response)
             )
 
             expect(logger).to receive(:info).exactly(3).times
-            subject.perform(type, id, attribute_params)
+            subject.perform(type, id, options)
           end
         end
 
@@ -185,12 +186,12 @@ RSpec.describe I18nSonder::Workers::UploadSourceStringsWorker do
             expect(model_instance).to receive(:update).with(french_attrs).exactly(:once)
             expect(adapter).to(
                 receive(:upload_attributes_to_translate)
-                    .with(type, id.to_s, updated, attributes_to_translate, attribute_params)
+                    .with(type, id.to_s, updated, attributes_to_translate, options)
                     .and_return(upload_response)
             )
 
             expect(logger).to receive(:info).exactly(2).times
-            subject.perform(type, id, attribute_params)
+            subject.perform(type, id, options)
           end
         end
       end
@@ -204,4 +205,3 @@ RSpec.describe I18nSonder::Workers::UploadSourceStringsWorker do
     t
   end
 end
-

--- a/spec/mobility/plugins/upload_for_translation_spec.rb
+++ b/spec/mobility/plugins/upload_for_translation_spec.rb
@@ -7,12 +7,14 @@ RSpec.describe Mobility::Plugins::UploadForTranslation do
   }
   let(:id) { 1 }
   let(:attribute_params) { { "title" => {}, "content" => { split_sentences: false } } }
+  let(:namespace) { nil }
+  let(:options) { { translated_attribute_params: attribute_params, namespace: namespace } }
   let(:instance) { Post.new(id: id, title: "T1", content: "some content", published: true) }
 
   it "calls async worker with correct params and delay on creation" do
     # worker will be called twice on creation, once per translatabe field
     expect(worker_class_mock).to(
-        receive(:perform_in).with(5.minutes, 'Post', id, attribute_params).exactly(2).times
+        receive(:perform_in).with(5.minutes, 'Post', id, options).exactly(2).times
     )
     instance.save!
   end
@@ -20,7 +22,7 @@ RSpec.describe Mobility::Plugins::UploadForTranslation do
   it "calls async worker with correct params and delay on update" do
     # worker will be called twice on creation, and then once on update
     expect(worker_class_mock).to(
-        receive(:perform_in).with(5.minutes, 'Post', id, attribute_params).exactly(3).times
+        receive(:perform_in).with(5.minutes, 'Post', id, options).exactly(3).times
     )
     instance.save!
     instance.update!(content: "new content")
@@ -70,9 +72,9 @@ RSpec.describe Mobility::Plugins::UploadForTranslation do
       end
 
       let(:allowed) { false }
-      it "does not upload for translation" do
+      it "uploads for translation" do
         expect(worker_class_mock).to(
-            receive(:perform_in).with(5.minutes, 'Post', id, attribute_params).exactly(2).times
+            receive(:perform_in).with(5.minutes, 'Post', id, options).exactly(2).times
         )
         instance.save!
       end
@@ -82,6 +84,22 @@ RSpec.describe Mobility::Plugins::UploadForTranslation do
       class Post < ActiveRecord::Base
         remove_method(:allowed_for_translation?)
       end
+    end
+  end
+
+  context "for instance with namespace_for_translation method" do
+    let(:namespace) { ["dummy_namespace"] }
+    before do
+      class Post < ActiveRecord::Base
+        def namespace_for_translation; ["dummy_namespace"]; end
+      end
+    end
+
+    it "uploads for translation" do
+      expect(worker_class_mock).to(
+          receive(:perform_in).with(5.minutes, 'Post', id, options).exactly(2).times
+      )
+      instance.save!
     end
   end
 end


### PR DESCRIPTION
This introduces the concept of namespacing source strings. Models that use the UploadForTranslation Mobiliy plugin can now implement a `namespace_for_translation` method, which returns an array specifying the namespace hierarchy to store source strings in.

In CrowdIn, this namespace hierarchy will be organized as directories.

### CAVEAT ###
Even though the namespace is represented as an array in order to represent a hierarchy, in this PR we DO NOT allow for nested directories in CrowdIn. This is eventually desired, but can be done as a follow-up.