### PR TITLE
Rake task to upload all source strings in a Rails App

### DIFF
--- a/lib/i18n_sonder.rb
+++ b/lib/i18n_sonder.rb
@@ -7,6 +7,7 @@ require 'mobility/plugins/locale_optimized_query'
 require 'mobility/plugins/upload_for_translation'
 require 'i18n_sonder/workers/sync_approved_translations_worker'
 require 'i18n_sonder/workers/upload_source_strings_worker'
+require "i18n_sonder/railtie" if defined?(Rails)
 
 module I18nSonder
   class << self

--- a/lib/i18n_sonder.rb
+++ b/lib/i18n_sonder.rb
@@ -7,7 +7,7 @@ require 'mobility/plugins/locale_optimized_query'
 require 'mobility/plugins/upload_for_translation'
 require 'i18n_sonder/workers/sync_approved_translations_worker'
 require 'i18n_sonder/workers/upload_source_strings_worker'
-require "i18n_sonder/railtie" if defined?(Rails)
+require "i18n_sonder/railtie"
 
 module I18nSonder
   class << self

--- a/lib/i18n_sonder.rb
+++ b/lib/i18n_sonder.rb
@@ -37,5 +37,10 @@ module I18nSonder
        config_val = I18nSonder.configuration.languages_to_translate
        config_val.present? ? config_val : I18n.available_locales
     end
+
+    def apply_duplicate_translations_on_upload
+      config_val = I18nSonder.configuration.apply_duplicate_translations_on_upload
+      config_val.present? ? config_val : false
+    end
   end
 end

--- a/lib/i18n_sonder/configuration.rb
+++ b/lib/i18n_sonder/configuration.rb
@@ -1,12 +1,14 @@
 module I18nSonder
   class Configuration
-    attr_accessor :crowdin_api_key, :crowdin_project_id, :logger, :languages_to_translate
+    attr_accessor :crowdin_api_key, :crowdin_project_id, :logger,
+    :languages_to_translate, :apply_duplicate_translations_on_upload
 
     def initialize
       self.crowdin_api_key = nil
       self.crowdin_project_id = nil
       self.logger = nil
       self.languages_to_translate = nil
+      self.apply_duplicate_translations_on_upload = nil
     end
   end
 end

--- a/lib/i18n_sonder/railtie.rb
+++ b/lib/i18n_sonder/railtie.rb
@@ -1,0 +1,5 @@
+class I18nSonder::Railtie < Rails::Railtie
+  rake_tasks do
+    load 'tasks/upload_source_strings_for_translation.rake'
+  end
+end

--- a/lib/i18n_sonder/workers/upload_source_strings_worker.rb
+++ b/lib/i18n_sonder/workers/upload_source_strings_worker.rb
@@ -32,11 +32,10 @@ module I18nSonder
         object = klass.find(object_id)
         if object.present?
           updated_at = object.has_attribute?(:updated_at) ? object.updated_at.to_i : nil
-          attributes_to_translate = handle_duplicates(
-              object,
-              klass,
-              object.attributes.slice(*options[:translated_attribute_params]&.keys)
-          )
+          attributes_to_translate = object.attributes.slice(*options[:translated_attribute_params]&.keys)
+          if options[:handle_duplicates]
+            attributes_to_translate = handle_duplicates(object, klass, attributes_to_translate)
+          end
 
           @logger.info("#{@log_pre} Uploading attributes #{attributes_to_translate.keys} to translate for #{object_type} #{object_id}")
           result = localization_provider.upload_attributes_to_translate(

--- a/lib/mobility/plugins/upload_for_translation.rb
+++ b/lib/mobility/plugins/upload_for_translation.rb
@@ -31,7 +31,8 @@ module Mobility
               model[:id],
               {
                 translated_attribute_params: translated_attribute_params,
-                namespace: namespace
+                namespace: namespace,
+                handle_duplicates: I18nSonder.apply_duplicate_translations_on_upload
               }
           )
         end

--- a/lib/tasks/upload_source_strings_for_translation.rake
+++ b/lib/tasks/upload_source_strings_for_translation.rake
@@ -1,0 +1,57 @@
+# This rake task takes in a model name as a string. It is case sensitive.
+# So, a model class named "Foo" will error if "foo" is passed in as the argument.
+# For models that are namespaced, e.g. "Foo::BarBaz",
+# the string argument would be "Foo_BarBaz".
+namespace :i18n_sonder do
+  desc "Upload the source strings for all objects of a given model type for translation"
+  task :upload_source_strings_for_translation, [:model_name] => :environment do |_task, args|
+
+    if args[:model_name].present?
+      klasses = [args[:model_name].constantize]
+    else
+      # We get all DIRECT subclasses of ApplicationRecord, rather than all descendents
+      # since the table containing source strings will be a direct subclass of
+      # ActiveRecord. We don't need to process derived models.
+      klasses = ApplicationRecord.subclasses.select { |m| m.included_modules.include?(Mobility::ActiveRecord) }
+    end
+
+    uploader = I18nSonder::Workers::UploadSourceStringsWorker.new
+
+    klasses.each do |klass|
+      Rails.logger.info("[upload_source_strings_for_translation] Beginning upload for #{klass}")
+      total = 0
+
+      klass.in_batches.each do |batch|
+        batch.each do |obj|
+          # Check if model has the method defined and if it evaluates to true
+          model_allowed_for_translation = !klass.method_defined?(:allowed_for_translation?) ||
+              obj.allowed_for_translation?
+
+          if model_allowed_for_translation
+            # Get translated attributes, and each attribute's params for uploading translations
+            translated_attribute_names = klass.translated_attribute_names
+            translated_attribute_params = {}
+            translated_attribute_names.each do |attribute_name|
+              upload_options = obj.public_send("#{attribute_name}_backend").options[:upload_for_translation]
+              translated_attribute_params[attribute_name] = upload_options.is_a?(Hash) ? upload_options : {}
+            end
+
+            namespace = obj.namespace_for_translation if klass.method_defined?(:namespace_for_translation)
+
+            uploader.perform(
+                obj.class.name,
+                obj[:id],
+                {
+                  translated_attribute_params: translated_attribute_params,
+                  namespace: namespace
+                }
+            )
+          end
+        end
+
+        total += batch.count
+        Rails.logger.info("[upload_source_strings_for_translation] Uploaded source strings for #{total} #{klass} objects")
+      end
+    end
+  end
+end

--- a/spec/i18n_sonder/workers/upload_source_strings_worker_spec.rb
+++ b/spec/i18n_sonder/workers/upload_source_strings_worker_spec.rb
@@ -38,11 +38,6 @@ RSpec.describe I18nSonder::Workers::UploadSourceStringsWorker do
       expect(I18nSonder).to receive(:localization_provider).and_return(adapter)
 
       allow(model).to receive(:find).with(id).and_return(model_instance)
-      allow(subject).to receive(:translation_table_name).and_return("t")
-      allow(model).to receive(:joins).and_return(model)
-      allow(model).to receive(:select).and_return(model)
-      allow(model).to receive(:where).and_return(model)
-      allow(model).to receive(:order).and_return(duplicates)
       allow(model_instance).to receive(:has_attribute?).with(:updated_at).and_return(has_updated_at)
       allow(model_instance).to receive(:id).and_return(id)
     end
@@ -110,6 +105,15 @@ RSpec.describe I18nSonder::Workers::UploadSourceStringsWorker do
     end
 
     context "with duplicates" do
+      before do
+        allow(subject).to receive(:translation_table_name).and_return("t")
+        allow(model).to receive(:joins).and_return(model)
+        allow(model).to receive(:select).and_return(model)
+        allow(model).to receive(:where).and_return(model)
+        allow(model).to receive(:order).and_return(duplicates)
+      end
+
+      let(:options) { { translated_attribute_params: attribute_params, handle_duplicates: true } }
       let(:translation1) { create_translation("french val 1", "fr") }
       let(:translation2) { create_translation("french val 3", "fr") }
       let(:translation3) { create_translation("spanish val 1", "es") }

--- a/spec/mobility/plugins/upload_for_translation_spec.rb
+++ b/spec/mobility/plugins/upload_for_translation_spec.rb
@@ -8,7 +8,13 @@ RSpec.describe Mobility::Plugins::UploadForTranslation do
   let(:id) { 1 }
   let(:attribute_params) { { "title" => {}, "content" => { split_sentences: false } } }
   let(:namespace) { nil }
-  let(:options) { { translated_attribute_params: attribute_params, namespace: namespace } }
+  let(:options) {
+    {
+      translated_attribute_params: attribute_params,
+      namespace: namespace,
+      handle_duplicates: false
+    }
+  }
   let(:instance) { Post.new(id: id, title: "T1", content: "some content", published: true) }
 
   it "calls async worker with correct params and delay on creation" do


### PR DESCRIPTION
This task takes an argument to only upload source strings for a given model. If no argument is passed in, the it attempts to find all models that extend Mobility, and processes those models.

The rake task is synchronous, so as to not overload CrowdIn.

The other change made here is to make the `handle_duplicates` optional in the UploadSourceStringsWorker. For bootstrapping, we don't want to ignore duplicates. The `handle_duplicates` option is now configured as a project level configuration parameter in the Rails App that uses this gem