### PR TITLE
SyncTranslationsWorker which syncs all translations

### DIFF
--- a/lib/crowdin/adapter.rb
+++ b/lib/crowdin/adapter.rb
@@ -79,7 +79,7 @@ module CrowdIn
       end
     end
 
-    # Given a language, fetch approved translations.
+    # Given a language, fetch all translations.
     # Returns Struct of approved translations hash, and/or failures.
     # Approved translations have the format:
     # {
@@ -95,6 +95,31 @@ module CrowdIn
     # 1) +CrowdIn::Client::Errors::Error+ if we fail to fetch the translation status of files
     # 2) +CrowdIn::FileMethods::FilesError+ if any individual files fail on export
     def translations(language)
+      begin
+        file_status_list = @client.language_status(language)
+        file_ids = file_status_list.map { |f| f['file_id'] }
+        translations_for_files(file_ids, language)
+      rescue CrowdIn::Client::Errors::Error => e
+        ReturnObject.new({}, e)
+      end
+    end
+
+    # Given a language, fetch approved translations.
+    # Returns Struct of approved translations hash, and/or failures.
+    # Approved translations have the format:
+    # {
+    #   model: {
+    #     id: {
+    #       field_1: val1,
+    #       field_2: val2
+    #     }
+    #   }
+    # }
+    #
+    # Failures can be:
+    # 1) +CrowdIn::Client::Errors::Error+ if we fail to fetch the translation status of files
+    # 2) +CrowdIn::FileMethods::FilesError+ if any individual files fail on export
+    def approved_translations(language)
       begin
         file_status_list = @client.language_status(language)
       rescue CrowdIn::Client::Errors::Error => e

--- a/lib/i18n_sonder.rb
+++ b/lib/i18n_sonder.rb
@@ -5,6 +5,7 @@ require 'crowdin/adapter'
 require 'mobility/backends/default_locale_optimized_key_value'
 require 'mobility/plugins/locale_optimized_query'
 require 'mobility/plugins/upload_for_translation'
+require 'i18n_sonder/workers/sync_translations_worker'
 require 'i18n_sonder/workers/sync_approved_translations_worker'
 require 'i18n_sonder/workers/upload_source_strings_worker'
 require "i18n_sonder/railtie"

--- a/lib/i18n_sonder/workers/sync_translations.rb
+++ b/lib/i18n_sonder/workers/sync_translations.rb
@@ -1,0 +1,81 @@
+module I18nSonder
+  module Workers
+    module SyncTranslations
+      def sync(approved_translations_only:)
+        localization_provider = I18nSonder.localization_provider
+
+        successful_syncs = {}
+        # Iterate through each language we need to sync
+        languages_to_translate = I18nSonder.languages_to_translate.reject { |l| l == I18n.default_locale }
+        languages_to_translate.each do |language|
+          @logger.info("[#{self.class.name}] Fetching translations for #{language}")
+          # Fetch translations in the following format
+          # {
+          #   model: {
+          #     id: {
+          #       field_1: val1,
+          #       field_2: val2
+          #     }
+          #   }
+          # }
+          if approved_translations_only
+            translation_result = localization_provider.approved_translations(language.to_s)
+          else
+            translation_result = localization_provider.translations(language.to_s)
+          end
+          translations_by_model_and_id = translation_result.success
+          handle_failure(translation_result.failure)
+
+          begin
+            write_translations(translations_by_model_and_id, language)
+          rescue => e
+            handle_failure(e)
+          else
+            # All translations were written successfully in this language
+            successful_syncs = process_successful_syncs(translations_by_model_and_id, language, successful_syncs)
+          end
+        end
+
+        if approved_translations_only
+          @logger.info("[#{self.class.name}] Cleaning up translations")
+          cleanup_result = localization_provider.cleanup_translations(successful_syncs, languages_to_translate)
+          handle_failure(cleanup_result.failure)
+        end
+      end
+
+      # Update attributes in given language
+      def write_translations(translations_by_model_and_id, language)
+        # Write these translations to DB
+        translations_by_model_and_id.each do |model_name, translations_by_id|
+          translations_by_id.each do |id, translations|
+            @logger.info("[#{self.class.name}] Writing translations for #{model_name} #{id} in #{language}")
+            Mobility.with_locale(language) do
+              model_name.constantize.update(id, translations)
+            end
+          end
+        end
+      end
+
+      def process_successful_syncs(translations_by_model_and_id, language, successful_syncs)
+        translations_by_model_and_id.each do |model_name, ids|
+          ids.keys.each do |id|
+            if successful_syncs.dig(model_name, id)
+              successful_syncs[model_name][id].append(language)
+            elsif successful_syncs.key? model_name
+              successful_syncs[model_name][id] = [language]
+            else
+              successful_syncs[model_name] = { id => [language] }
+            end
+          end
+        end
+        successful_syncs
+      end
+
+      def handle_failure(exception)
+        if exception.is_a? Exception
+          @logger.error("[#{self.class.name}] #{exception}")
+        end
+      end
+    end
+  end
+end

--- a/lib/i18n_sonder/workers/sync_translations_worker.rb
+++ b/lib/i18n_sonder/workers/sync_translations_worker.rb
@@ -1,8 +1,9 @@
 require 'sidekiq'
+require 'i18n_sonder/workers/sync_translations'
 
 module I18nSonder
   module Workers
-    class SyncApprovedTranslationsWorker
+    class SyncTranslationsWorker
       include Sidekiq::Worker
       include I18nSonder::Workers::SyncTranslations
 
@@ -13,7 +14,7 @@ module I18nSonder
       end
 
       def perform
-        sync(approved_translations_only: true)
+        sync(approved_translations_only: false)
       end
     end
   end


### PR DESCRIPTION
Previously, SyncApprovedTranslationsWorker would only sync approved translations. This introduces a new worker that will sync all translations, since we are moving to a world where we want to pull down unapproved Google translations, and not be blocked on a human approving the translations.