### PR TITLE
Refactor bootstrap to use UploadSourceStrings

### DIFF
--- a/lib/i18n_sonder/workers/upload_source_strings_worker.rb
+++ b/lib/i18n_sonder/workers/upload_source_strings_worker.rb
@@ -25,6 +25,7 @@ module I18nSonder
       # - +namespace+ is an option that specifies the directory to upload the source strings to,
       # if that is desired.
       def perform(object_type, object_id, options)
+        options = options.transform_keys(&:to_sym)
         localization_provider = I18nSonder.localization_provider
 
         # Find the object and all its localized attributes

--- a/lib/mobility/plugins/upload_for_translation.rb
+++ b/lib/mobility/plugins/upload_for_translation.rb
@@ -15,7 +15,7 @@ module Mobility
       def write(locale, value, options = {})
         return unless should_upload_for_translation?(value, attribute)
 
-        I18nSonder::UploadSourceStrings.new(model).upload(locale)
+        I18nSonder::UploadSourceStrings.new(model).upload_async(locale)
 
         super
       end

--- a/lib/tasks/upload_source_strings_for_translation.rake
+++ b/lib/tasks/upload_source_strings_for_translation.rake
@@ -37,7 +37,7 @@ namespace :i18n_sonder do
       I18nSonder.logger.error("[upload_source_strings_for_translation] Beginning upload for #{klass}")
     else
       klass = args[:model_name].constantize
-      id = klass.find(args[:model_id])
+      obj = klass.find(args[:model_id])
 
       I18nSonder.logger.info("[upload_source_strings_for_translation] Uploaded source strings for #{total} #{klass} objects")
       I18nSonder::Upload.new(obj).upload(I18n::default_locale)

--- a/lib/tasks/upload_source_strings_for_translation.rake
+++ b/lib/tasks/upload_source_strings_for_translation.rake
@@ -37,10 +37,15 @@ namespace :i18n_sonder do
       I18nSonder.logger.error("[upload_source_strings_for_translation] Beginning upload for #{klass}")
     else
       klass = args[:model_name].constantize
+      id = args[:model_id]
       obj = klass.find(args[:model_id])
 
-      I18nSonder.logger.info("[upload_source_strings_for_translation] Uploaded source strings for #{total} #{klass} objects")
-      I18nSonder::Upload.new(obj).upload(I18n::default_locale)
+      if obj.present?
+        I18nSonder.logger.info("[upload_source_strings_for_translation] Uploaded source strings for #{klass} #{id}")
+        I18nSonder::Upload.new(obj).upload(I18n::default_locale)
+      else
+        I18nSonder.logger.error("[upload_source_strings_for_translation] Can't find #{klass} #{id}")
+      end
     end
   end
 end

--- a/spec/i18n_sonder/upload_source_strings_spec.rb
+++ b/spec/i18n_sonder/upload_source_strings_spec.rb
@@ -20,9 +20,23 @@ RSpec.describe I18nSonder::UploadSourceStrings do
   let(:value) { nil }
   let(:attribute) { nil }
 
-  subject(:upload) { described_class.new(instance).upload(locale) }
-
   describe '#upload' do
+    subject(:upload) { described_class.new(instance).upload(locale) }
+
+    let(:worker_mock) { instance_double(I18nSonder::Workers::UploadSourceStringsWorker) }
+    let(:locale) { :en }
+
+    it "calls worker's perform synchronously with correct params" do
+      allow(worker_class_mock).to receive(:perform_in)
+      expect(I18nSonder::Workers::UploadSourceStringsWorker).to receive(:new).and_return(worker_mock)
+      expect(worker_mock).to receive(:perform).with('Post', id, options).once
+      upload
+    end
+  end
+
+  describe '#upload_async' do
+    subject(:upload) { described_class.new(instance).upload_async(locale) }
+
     it 'calls async worker with correct params and delay' do
       # worker will be called twice, once per translatable field
       expect(worker_class_mock).to(


### PR DESCRIPTION
This also adds a bugfix to symbolize all keys in the perform function of `UploadSourceStringsWorker` since sidekiq doesn't pass a hash with symbolized keys.