### PR TITLE
Sync translations in batches

### DIFF
--- a/lib/i18n_sonder/workers/sync_translations_worker.rb
+++ b/lib/i18n_sonder/workers/sync_translations_worker.rb
@@ -7,7 +7,7 @@ module I18nSonder
       include Sidekiq::Worker
       include I18nSonder::Workers::SyncTranslations
 
-      sidekiq_options retry: 2
+      sidekiq_options retry: false
 
       def initialize
         @logger = I18nSonder.logger


### PR DESCRIPTION
Fetch a batch of translations, and write them to DB. This is more memory efficient than fetching ALL translations, holding them in memory, and writing them to the DB subsequently.

Other optimizations:
* Turn off retries in SyncTranslations - it's too expensive for a long running process.
* When fetching all translations, we don't need to get language statuses for each file, we just need to fetch all files.
* Improve logging in CrowdIn client so that we know what request failed.