### PR TITLE
Sync all duplicate strings when syncing translation

### DIFF
--- a/lib/crowdin/adapter.rb
+++ b/lib/crowdin/adapter.rb
@@ -187,8 +187,10 @@ module CrowdIn
       end
 
       begin
-        source_string_context = @client.source_string(source_string_id)["context"]
+        source_string = @client.source_string(source_string_id)
+        source_string_context = source_string["context"]
         model_name, model_id, _updated, field_name = source_string_context.split(" -> ")
+        source_string_text = source_string["text"]
 
         translation_text = @client.translation(translation_id)["text"]
       rescue CrowdIn::Client::Errors::Error => e
@@ -196,9 +198,18 @@ module CrowdIn
       else
         ReturnObject.new(
           {
-            model_name => {
-              model_id => {
-                field_name => translation_text
+            'source_text' => {
+              model_name => {
+                model_id => {
+                  field_name => source_string_text
+                }
+              }
+            },
+            'translation' => {
+              model_name => {
+                model_id => {
+                  field_name => translation_text
+                }
               }
             }
           },

--- a/lib/i18n_sonder/workers/sync_approved_translations_worker.rb
+++ b/lib/i18n_sonder/workers/sync_approved_translations_worker.rb
@@ -12,8 +12,8 @@ module I18nSonder
         @logger = I18nSonder.logger
       end
 
-      def perform
-        sync(approved_translations_only: true)
+      def perform(languages = nil)
+        sync(approved_translations_only: true, languages: languages)
       end
     end
   end

--- a/lib/i18n_sonder/workers/sync_translations.rb
+++ b/lib/i18n_sonder/workers/sync_translations.rb
@@ -4,12 +4,16 @@ module I18nSonder
 
       BATCH_SIZE = 500
 
-      def sync(approved_translations_only:)
+      def sync(approved_translations_only:, languages: nil)
         localization_provider = I18nSonder.localization_provider
 
         successful_syncs = {}
         # Iterate through each language we need to sync
-        languages_to_translate = I18nSonder.languages_to_translate.reject { |l| l == I18n.default_locale }
+        if languages.present?
+          languages_to_translate = languages
+        else
+          languages_to_translate = I18nSonder.languages_to_translate.reject { |l| l == I18n.default_locale }
+        end
         languages_to_translate.each do |language|
           @logger.info("[#{self.class.name}] Fetching translations for #{language}")
           # Fetch translations in the following format

--- a/lib/i18n_sonder/workers/sync_translations.rb
+++ b/lib/i18n_sonder/workers/sync_translations.rb
@@ -39,13 +39,52 @@ module I18nSonder
         end
       end
 
-      def process_translation_result(translation_result, language, successful_syncs)
-        translations_by_model_and_id = translation_result.success
+      def process_translation_result(translation_result,
+                                     language,
+                                     successful_syncs,
+                                     handle_duplicates = false)
+        translations_and_source_text = translation_result.success
         handle_failure(translation_result.failure)
+        return unless translations_and_source_text.present?
+
+        if handle_duplicates
+          translations_by_model_and_id = all_duplicate_translations(
+            translations_and_source_text, language
+          )
+        else
+          translations_by_model_and_id = translations_and_source_text
+        end
 
         write_translations(translations_by_model_and_id, language)
 
         process_successful_syncs(translations_by_model_and_id, language, successful_syncs)
+      end
+
+      def all_duplicate_translations(translations_and_source_text, language)
+        translations_by_model_and_id = Hash.new { |h1,k1|
+          h1[k1] = Hash.new { |h2,k2| h2[k2] = {} }
+        }
+
+        translations_and_source_text['source_text'].each do |model_name, translations_by_id|
+          translations_by_id.each do |id, translations|
+            translations.each do |attr, value|
+              translation = translations_and_source_text.dig(
+                'translation', model_name, id, attr
+              )
+
+              duplicate_ids = model_name.constantize
+                                        .where("#{attr} = ?", value)
+                                        .pluck(:id)
+
+              duplicate_ids.each do |duplicate_id|
+                duplicate_model = translations_by_model_and_id[model_name]
+                duplicate_model[duplicate_id][attr] = translation
+              end
+            end
+          end
+        end
+
+        translations_by_model_and_id
       end
 
       # Update attributes in given language

--- a/lib/i18n_sonder/workers/sync_translations_worker.rb
+++ b/lib/i18n_sonder/workers/sync_translations_worker.rb
@@ -13,8 +13,8 @@ module I18nSonder
         @logger = I18nSonder.logger
       end
 
-      def perform
-        sync(approved_translations_only: false)
+      def perform(languages = nil)
+        sync(approved_translations_only: false, languages: languages)
       end
     end
   end

--- a/lib/i18n_sonder/workers/upsert_translation_worker.rb
+++ b/lib/i18n_sonder/workers/upsert_translation_worker.rb
@@ -16,7 +16,7 @@ module I18nSonder
       def perform(language, translation_id, source_string_id)
         localization_provider = I18nSonder.localization_provider
         translation_result = localization_provider.translation_by_id(translation_id, source_string_id)
-        process_translation_result(translation_result, language, {})
+        process_translation_result(translation_result, language, {}, true)
       end
     end
   end

--- a/lib/i18n_sonder/workers/upsert_translation_worker.rb
+++ b/lib/i18n_sonder/workers/upsert_translation_worker.rb
@@ -16,7 +16,7 @@ module I18nSonder
       def perform(language, translation_id, source_string_id)
         localization_provider = I18nSonder.localization_provider
         translation_result = localization_provider.translation_by_id(translation_id, source_string_id)
-        process_translation_result(translation_result, language, {}, true)
+        process_translation_result_with_duplicates(translation_result, language, {})
       end
     end
   end

--- a/spec/i18n_sonder/workers/sync_translations_spec.rb
+++ b/spec/i18n_sonder/workers/sync_translations_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe I18nSonder::Workers::SyncTranslations do
     end
   end
 
-  context "#process_translation_result with handling duplicates" do
+  context "#process_translation_result_with_duplicates" do
     let(:translations) {
       {
         "source_text" => {
@@ -155,7 +155,7 @@ RSpec.describe I18nSonder::Workers::SyncTranslations do
       expect(model).to receive(:update).with(3, { "field1" => "translation1"} )
       expect(model).to receive(:update).with(2, { "field2" => "translation2"} )
       expect(logger).to receive(:info).exactly(3).times
-      subject.process_translation_result(translations_response, :fr, {}, true)
+      subject.process_translation_result_with_duplicates(translations_response, :fr, {})
     end
   end
 end

--- a/spec/i18n_sonder/workers/sync_translations_spec.rb
+++ b/spec/i18n_sonder/workers/sync_translations_spec.rb
@@ -123,4 +123,39 @@ RSpec.describe I18nSonder::Workers::SyncTranslations do
       end
     end
   end
+
+  context "#process_translation_result with handling duplicates" do
+    let(:translations) {
+      {
+        "source_text" => {
+          "Model" => {
+            "1" => { "field1" => "source1" },
+            "2" => { "field2" => "source2" }
+          }
+        },
+        "translation" => {
+          "Model" => {
+            "1" => { "field1" => "translation1" },
+            "2" => { "field2" => "translation2" }
+          }
+        }
+      }
+    }
+    let(:translations_response) { CrowdIn::Adapter::ReturnObject.new(translations, nil) }
+
+    before do
+      I18n.available_locales = [:en, :fr]
+      I18n.default_locale = :en
+    end
+
+    it "fetches all duplicates to sync" do
+      expect(model).to receive(:where).with("field1 = ?", "source1").and_return([{ id: 1 }, { id: 3 }])
+      expect(model).to receive(:where).with("field2 = ?", "source2").and_return([{ id: 2 }])
+      expect(model).to receive(:update).with(1, { "field1" => "translation1"} )
+      expect(model).to receive(:update).with(3, { "field1" => "translation1"} )
+      expect(model).to receive(:update).with(2, { "field2" => "translation2"} )
+      expect(logger).to receive(:info).exactly(3).times
+      subject.process_translation_result(translations_response, :fr, {}, true)
+    end
+  end
 end

--- a/spec/i18n_sonder/workers/upsert_translation_worker_spec.rb
+++ b/spec/i18n_sonder/workers/upsert_translation_worker_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe I18nSonder::Workers::UpsertTranslationWorker do
       )
       expect(model).not_to receive(:update)
       expect(logger).not_to receive(:info)
-      expect(logger).to receive(:error).once
+      expect(logger).to receive(:error).twice
       subject.perform(language, translation_id, source_string_id)
     end
   end

--- a/spec/i18n_sonder/workers/upsert_translation_worker_spec.rb
+++ b/spec/i18n_sonder/workers/upsert_translation_worker_spec.rb
@@ -22,7 +22,12 @@ RSpec.describe I18nSonder::Workers::UpsertTranslationWorker do
     class_double(Model).as_stubbed_const(transfer_nested_constants: true)
   end
   let(:model_instance) { instance_double(model) }
-  let(:translation) { { "Model" => { "123" => { "field1" => "val 1" } } } }
+  let(:translation) {
+    {
+      "source_text" => { "Model" => { "1" => { "field1" => "source1" } } },
+      "translation" => { "Model" => { "1" => { "field1" => "translation1" } } }
+    }
+  }
   let(:translation_response) { CrowdIn::Adapter::ReturnObject.new(translation, nil) }
 
   let(:error) { CrowdIn::Client::Errors::Error.new(404, "not found") }
@@ -38,7 +43,8 @@ RSpec.describe I18nSonder::Workers::UpsertTranslationWorker do
           .with(translation_id, source_string_id)
           .and_return(translation_response)
       )
-      expect(model).to receive(:update).with('123', translation['Model']['123'])
+      expect(model).to receive(:where).with("field1 = ?", "source1").and_return([{ id: 1 }])
+      expect(model).to receive(:update).with(1, translation.dig('translation', 'Model', '1'))
       expect(logger).to receive(:info).exactly(1).times
       expect(logger).not_to receive(:error)
       subject.perform(language, translation_id, source_string_id)


### PR DESCRIPTION
Currently, when Crowdin webhooks are triggered with translation updates, only one string's translation gets triggered. However, we have many duplicates of those strings in our DB and in Crowdin, which do not end up getting translations stored for them.

In this PR, in the `SyncTranslations` module, we allow an optional parameter to handle duplicates. We simply look for duplicate instances in the database for that string, and update the translations for those strings as well.

Note, this process may take time, but this is ok since these webhooks are asynchronous calls anyways.

Lastly, to complete the process, on upload we also need to check whether there are other, already translated, instances of this string. If there are then we can automatically apply translations, rather than have to upload them to CrowdIn. This logic is already taken care of in `UploadSourceStringsWorker`.


## Testing ##
I tested this by locally having listings platform pull in these changes, starting LP behind ngrok, and setting up a new Test webhook on CrowdIn to try and hit this endpoint with updates. That showed the fetch for duplicate strings and their updates.