### PR TITLE
[REJUVENATE] allow mobility gem dependency to use any version after 0.8.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 0.0.2
+
+### 0.0.2 (Aug 30, 2022)
+
+* update to allow any version of the Mobility gem dependency past 0.8.9

--- a/i18n_sonder.gemspec
+++ b/i18n_sonder.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'mobility', '~> 0.8.9'
+  spec.add_dependency 'mobility', '>= 0.8.9'
   spec.add_dependency 'rest-client', '~> 2.0'
   spec.add_dependency 'sidekiq'
   spec.add_dependency 'rack', '>= 2.0.6'

--- a/lib/i18n_sonder/version.rb
+++ b/lib/i18n_sonder/version.rb
@@ -1,3 +1,3 @@
 module I18nSonder
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
[Asana Task](https://app.asana.com/0/1202544254420482/1202652673064898/f)

while this gem doesn't depend on Rails, we are updating flatbook to rails 6.1 and eventually 7.0.  This requires the mobility gem to be updated past 1.1.3