### PR TITLE
fix: pass keyword arguments instead of hash

### DIFF
--- a/lib/mobility/backends/default_locale_optimized_key_value.rb
+++ b/lib/mobility/backends/default_locale_optimized_key_value.rb
@@ -7,11 +7,11 @@ module Mobility
     # in our case English, are made against the native table of the Model, rather
     # than the translation tables.
     class DefaultLocaleOptimizedKeyValue < Mobility::Backends::ActiveRecord::KeyValue
-      def read(locale, options = {})
+      def read(locale, **options)
         if locale == I18n.default_locale
           model.read_attribute(attribute)
         else
-          super(locale, options)
+          super(locale, **options)
         end
       end
 
@@ -19,13 +19,13 @@ module Mobility
       # For example, if the `locale` is "en-GB", and the default_locale is "en",
       # we treat "en-GB" as the default locale and write to the model's table,
       # rather than to the translation table.
-      def write(locale, value, options = {})
+      def write(locale, value, **options)
         locale_without_region = locale.to_s.split("-").first
         default_locale_without_region = I18n.default_locale.to_s.split("-").first
         if locale_without_region == default_locale_without_region
           model.write_attribute(attribute, value)
         else
-          super(locale, value, options)
+          super(locale, value, **options)
         end
       end
     end

--- a/lib/mobility/plugins/callback_on_write.rb
+++ b/lib/mobility/plugins/callback_on_write.rb
@@ -14,7 +14,7 @@ module Mobility
         end
       end
 
-      def write(locale, value, options = {})
+      def write(locale, value, **options)
         return unless should_execute_callback?(value, attribute, locale)
 
         super

--- a/lib/mobility/plugins/upload_for_translation.rb
+++ b/lib/mobility/plugins/upload_for_translation.rb
@@ -19,7 +19,7 @@ module Mobility
         end
       end
 
-      def write(locale, value, options = {})
+      def write(locale, value, **options)
         return unless should_upload_for_translation?(value, attribute)
 
         I18nSonder::UploadSourceStrings.new(model).upload_async(locale)


### PR DESCRIPTION
This is to support Ruby 3.0 as there's hash to keyword args are no longer supported.